### PR TITLE
Fix/update apm agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+.DS_Store

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure-elastic-apm "0.1.1"
+(defproject clojure-elastic-apm "0.2.0"
   :description "Clojure wrapper for Elastic APM Java Agent"
   :url "https://github.com/Yleisradio/clojure-elastic-apm"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -4,11 +4,11 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]]
-  :profiles {:dev {:jvm-opts ["-javaagent:lib/elastic-apm-agent-1.3.0.jar"
+  :profiles {:dev {:jvm-opts ["-javaagent:lib/elastic-apm-agent-1.10.0.jar"
                               "-Delastic.apm.service_name=test-service"
                               "-Delastic.apm.application_packages=clojure-elastic-apm"
                               "-Delastic.apm.server_urls=http://localhost:8200"
                               "-Delastic.apm.metrics_interval=1s"]
                    :dependencies [[clj-http "3.9.1"]
                                   [cheshire "5.8.1"]]}
-             :provided {:dependencies [[co.elastic.apm/apm-agent-api "1.3.0"]]}})
+             :provided {:dependencies [[co.elastic.apm/apm-agent-api "1.10.0"]]}})


### PR DESCRIPTION
The current version of the repo uses an older version of the APM agent which appears to break on newer Java versions, at least on Java 13.

This PR updates to the current version of the APM agent, and bumps the version number to signal that this could be a breaking change with older versions of Java.