### PR TITLE
Add URI pattern matching to wrap-apm-transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ will be matched against any requests, and only log a transaction for those that 
 
 The pattern format breaks up the URI into segments on the slashes ("/") and matches the segments with the following syntax:
 - `*`: matches any data in the segment, and keeps it in the resulting transaction name
-- `_`: matches any data in the segment, but ignores it in the resulting tx name, instead inserting an asterisk('*') character
+- `_`: matches any data in the segment, but ignores it in the resulting tx name, instead inserting an underscore('_') character
 - any other string: matches only if the segment in the pattern and the URI match exactly, and retains the string in the tx name
 
 In the example above, the URI `/v1/foo/124` would match and yield `/v1/foo/*` as the tx name, while `/v1/foo` would not. This allows you to both ignore all but a specific set of URLs, while also grouping URLs in the APM tx logs by leaving out 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ will be matched against any requests, and only log a transaction for those that 
 
 The pattern format breaks up the URI into segments on the slashes ("/") and matches the segments with the following syntax:
 - `*`: matches any data in the segment, and keeps it in the resulting transaction name
-- `_`: matches any data in the segment, but ignores it in the resulting tx name, instead inserting a splat('*') character
+- `_`: matches any data in the segment, but ignores it in the resulting tx name, instead inserting an asterisk('*') character
 - any other string: matches only if the segment in the pattern and the URI match exactly, and retains the string in the tx name
 
 In the example above, the URI `/v1/foo/124` would match and yield `/v1/foo/*` as the tx name, while `/v1/foo` would not. This allows you to both ignore all but a specific set of URLs, while also grouping URLs in the APM tx logs by leaving out 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,33 @@ For convenience, the `clojure-elastic-apm.ring` namespace provides `wrap-apm-tra
 
 With this setup, all requests will be tracked as APM transactions with `"request"` type. The transaction will be named `METHOD /path`.
 
+#### Filtering and matching URIs
+
+The `wrap-apm-transaction` middleware takes an optional argument, that allows you to pass a list of URI patterns, which 
+will be matched against any requests, and only log a transaction for those that match the pattern:
+
+```clojure
+(require '[clojure-elastic-apm.ring :as apm-ring])
+
+(def app (->> app-routes
+              wrap-params
+              wrap-json-params
+              apm-ring/wrap-apm-transaction ["/*/*/_"]))
+```
+
+The pattern format breaks up the URI into segments on the slashes ("/") and matches the segments with the following syntax:
+- `*`: matches any data in the segment, and keeps it in the resulting transaction name
+- `_`: matches any data in the segment, but ignores it in the resulting tx name, instead inserting a splat('*') character
+- any other string: matches only if the segment in the pattern and the URI match exactly, and retains the string in the tx name
+
+In the example above, the URI `/v1/foo/124` would match and yield `/v1/foo/*` as the tx name, while `/v1/foo` would not. This allows you to both ignore all but a specific set of URLs, while also grouping URLs in the APM tx logs by leaving out 
+unnecessary extra detail like URL parameters.
+
+If any segments fail to match one of the given patterns, then no transaction is logged. The matcher will attempt to match
+the patterns in descending order as given in the vector. Matches are "eager": a short pattern like `"/*"` will match any URI, but ignore segments after it (so `/*` would match against `/v1/foo/bar` but only return `/v1`).
+
+#### Accessing the current transaction
+
 You can access the APM transaction created by the middleware from the request map under `:clojure-elastic-apm/transaction` key.
 
 No other request information will be added to the transaction. The APM Java Agent's Public API, at the time of writing this library, doesn't allow

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ will be matched against any requests, and only log a transaction for those that 
 (def app (->> app-routes
               wrap-params
               wrap-json-params
-              apm-ring/wrap-apm-transaction ["/*/*/_"]))
+              (apm-ring/wrap-apm-transaction ["/*/*/_"])))
 ```
 
 The pattern format breaks up the URI into segments on the slashes ("/") and matches the segments with the following syntax:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure-elastic-apm "0.2.2"
+(defproject clojure-elastic-apm "0.3.0"
   :description "Clojure wrapper for Elastic APM Java Agent"
   :url "https://github.com/Yleisradio/clojure-elastic-apm"
   :license {:name "Eclipse Public License"

--- a/src/clojure_elastic_apm/ring.clj
+++ b/src/clojure_elastic_apm/ring.clj
@@ -2,7 +2,7 @@
   (:require [clojure-elastic-apm.core :refer [with-apm-transaction
                                               type-request]]))
 
-(defn match-uris [pattern uri]
+(defn match-uri [pattern uri]
   (let [pattern-segs (clojure.string/split pattern #"/")
         uri-segs (clojure.string/split uri #"/")
         matcher (fn [p u]
@@ -32,7 +32,7 @@
   ([patterns handler]
    (fn [{:keys [request-method uri] :as request}]
      (let [matched (->> patterns
-                        (map #(match-uris % uri))
+                        (map #(match-uri % uri))
                         (drop-while false?)
                         (first))
            short-uri (if matched matched "_")

--- a/src/clojure_elastic_apm/ring.clj
+++ b/src/clojure_elastic_apm/ring.clj
@@ -2,11 +2,45 @@
   (:require [clojure-elastic-apm.core :refer [with-apm-transaction
                                               type-request]]))
 
-(defn wrap-apm-transaction [handler]
-  (fn [{:keys [request-method uri] :as request}]
-    (let [tx-name (str (.toUpperCase (name request-method)) " " uri)]
-      (with-apm-transaction [tx {:name tx-name :type type-request}]
-        (let [{:keys [status] :as response} (handler (assoc request :clojure-elastic-apm/transaction tx))]
-          (when status
-            (.setResult tx (str "HTTP " status)))
-          response)))))
+(defn match-uris [pattern uri]
+  (let [pattern-segs (clojure.string/split pattern #"/")
+        uri-segs (clojure.string/split uri #"/")
+        matcher (fn [p u]
+                  (cond
+                    (= p "*") u
+                    (= p "_") "*"
+                    (= p u) u
+                    :else false))]
+    (if (> (count pattern-segs)
+           (count uri-segs))
+      false
+      (let [matches (map matcher pattern-segs uri-segs)
+            matched? (reduce #(and %1 %2) matches)]
+        (if matched?
+          (clojure.string/join "/" matches)
+          matched?)))))
+
+(defn wrap-apm-transaction 
+  ([handler] 
+   (fn [{:keys [request-method uri] :as request}]
+     (let [tx-name (str (.toUpperCase (name request-method)) " " uri)]
+       (with-apm-transaction [tx {:name tx-name :type type-request}]
+         (let [{:keys [status] :as response} (handler (assoc request :clojure-elastic-apm/transaction tx))]
+           (when status
+             (.setResult tx (str "HTTP " status)))
+           response)))))
+  ([patterns handler]
+   (fn [{:keys [request-method uri] :as request}]
+     (let [matched (->> patterns
+                        (map #(match-uris % uri))
+                        (drop-while false?)
+                        (first))
+           short-uri (if matched matched "_")
+           tx-name (str (.toUpperCase (name request-method)) " " short-uri)]
+       (if matched
+         (with-apm-transaction [tx {:name tx-name :type type-request}]
+           (let [{:keys [status] :as response} (handler (assoc request :clojure-elastic-apm/transaction tx))]
+             (when status
+               (.setResult tx (str "HTTP " status)))
+             response))
+         (handler request))))))

--- a/src/clojure_elastic_apm/ring.clj
+++ b/src/clojure_elastic_apm/ring.clj
@@ -8,7 +8,7 @@
         matcher (fn [p u]
                   (cond
                     (= p "*") u
-                    (= p "_") "*"
+                    (= p "_") "_"
                     (= p u) u
                     :else false))]
     (if (> (count pattern-segs)

--- a/src/clojure_elastic_apm/ring.clj
+++ b/src/clojure_elastic_apm/ring.clj
@@ -35,8 +35,7 @@
                         (map #(match-uri % uri))
                         (drop-while false?)
                         (first))
-           short-uri (if matched matched "_")
-           tx-name (str (.toUpperCase (name request-method)) " " short-uri)]
+           tx-name (str (.toUpperCase (name request-method)) " " matched)]
        (if matched
          (with-apm-transaction [tx {:name tx-name :type type-request}]
            (let [{:keys [status] :as response} (handler (assoc request :clojure-elastic-apm/transaction tx))]

--- a/test/clojure_elastic_apm/ring_test.clj
+++ b/test/clojure_elastic_apm/ring_test.clj
@@ -32,7 +32,7 @@
                   (is (= (.getId (:clojure-elastic-apm/transaction request)) (.getId (apm/current-apm-transaction))) "transaction should've been activated for the duration of the request")
                   (reset! transaction-id (.getId (:clojure-elastic-apm/transaction request)))
                   response)
-        wrapped-handler (apm-ring/wrap-apm-transaction handler)]
+        wrapped-handler (apm-ring/wrap-apm-transaction ["/*/*"] handler)]
     (is (= (wrapped-handler request) response))
     (let [tx-details (es-find-first-document (str "(processor.event:transaction%20AND%20transaction.id:" @transaction-id ")"))]
       (is (= apm/type-request (get-in tx-details [:transaction :type])))

--- a/test/clojure_elastic_apm/ring_test.clj
+++ b/test/clojure_elastic_apm/ring_test.clj
@@ -9,8 +9,8 @@
     (= (apm-ring/match-uri "/*/*" "/v1/foo") "/v1/foo")
     (= (apm-ring/match-uri "/*/*/*" "/v1/foo/bar") "/v1/foo/bar"))
   (testing "_ matches but ignores value"
-    (= (apm-ring/match-uri "/*/_" "/v1/foo") "/v1/*")
-    (= (apm-ring/match-uri "/_/foo" "/v1/foo") "/*/foo"))
+    (= (apm-ring/match-uri "/*/_" "/v1/foo") "/v1/_")
+    (= (apm-ring/match-uri "/_/foo" "/v1/foo") "/_/foo"))
   (testing "exact string matches and returns value"
     (= (apm-ring/match-uri "/v1/*" "/v1/foo") "/v1/foo")
     (= (apm-ring/match-uri "/*/foo" "/v2/foo") "/v2/foo")


### PR DESCRIPTION
This adds a new feature to the `wrap-apm-transaction` middleware, so that you can give it a list of URI patterns to filter and group transactions better.

One open question is whether the matching should be eager, as it is here, or stricter (exact pattern match only). Making it eager did seem to fix some weird issues with trailing slashes possibly? But that's something that can probably be fixed.