### PR TITLE
Fix argument order for wrap-apm-transaction

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure-elastic-apm "0.3.0"
+(defproject clojure-elastic-apm "0.4.0"
   :description "Clojure wrapper for Elastic APM Java Agent"
   :url "https://github.com/Yleisradio/clojure-elastic-apm"
   :license {:name "Eclipse Public License"

--- a/src/clojure_elastic_apm/ring.clj
+++ b/src/clojure_elastic_apm/ring.clj
@@ -29,7 +29,7 @@
            (when status
              (.setResult tx (str "HTTP " status)))
            response)))))
-  ([patterns handler]
+  ([handler patterns]
    (fn [{:keys [request-method uri] :as request}]
      (let [matched (->> patterns
                         (map #(match-uri % uri))

--- a/test/clojure_elastic_apm/ring_test.clj
+++ b/test/clojure_elastic_apm/ring_test.clj
@@ -32,7 +32,7 @@
                   (is (= (.getId (:clojure-elastic-apm/transaction request)) (.getId (apm/current-apm-transaction))) "transaction should've been activated for the duration of the request")
                   (reset! transaction-id (.getId (:clojure-elastic-apm/transaction request)))
                   response)
-        wrapped-handler (apm-ring/wrap-apm-transaction ["/*/*"] handler)]
+        wrapped-handler (apm-ring/wrap-apm-transaction handler ["/*/*"])]
     (is (= (wrapped-handler request) response))
     (let [tx-details (es-find-first-document (str "(processor.event:transaction%20AND%20transaction.id:" @transaction-id ")"))]
       (is (= apm/type-request (get-in tx-details [:transaction :type])))


### PR DESCRIPTION
Convention for compojure middleware is to have the handler as the *first* argument, so that middleware are passed along with the single arrow (`->`) threading macro, but the new version of `wrap-apm-transaction` that came in 0.3.0 put it in the last argument position when using the filter list feature.

This makes for some annoying fiddliness when dealing with it and other middleware with multiple arguments, owing to the conflicting argument convention and the way threading macros work.

This version simply flips the argument order to follow standard convention, which will make it easier to use in the future. 