### PR TITLE
Upgrade elastic-apm-agent to 1.28.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:7.10.2"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:7.16.0"
     container_name: "elasticsearch"
     environment:
       - xpack.security.enabled=false
@@ -14,10 +14,10 @@ services:
       - "9200:9200"
       - "9300:9300"
   kibana:
-    image: "docker.elastic.co/kibana/kibana:7.10.2"
+    image: "docker.elastic.co/kibana/kibana:7.16.0"
     ports:
       - "5601:5601"
   apm-server:
-    image: "docker.elastic.co/apm/apm-server:7.10.2"
+    image: "docker.elastic.co/apm/apm-server:7.16.0"
     ports:
       - "8200:8200"

--- a/project.clj
+++ b/project.clj
@@ -4,11 +4,11 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.2"]]
-  :profiles {:dev {:jvm-opts ["-javaagent:lib/elastic-apm-agent-1.20.0.jar"
+  :profiles {:dev {:jvm-opts ["-javaagent:lib/elastic-apm-agent-1.28.1.jar"
                               "-Delastic.apm.service_name=test-service"
                               "-Delastic.apm.application_packages=clojure-elastic-apm"
                               "-Delastic.apm.server_urls=http://localhost:8200"
                               "-Delastic.apm.metrics_interval=1s"]
                    :dependencies [[clj-http "3.10.1"]
                                   [cheshire "5.10.0"]]}
-             :provided {:dependencies [[co.elastic.apm/apm-agent-api "1.20.0"]]}})
+             :provided {:dependencies [[co.elastic.apm/apm-agent-api "1.28.1"]]}})


### PR DESCRIPTION
This fixes the log4j vulnerability. Also updated the docker-compose env to use the latest stable version of elastic-stack.

`lein test` passes