### PR TITLE
Use Reitit route template for transaction path when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,13 @@ from request and the transaction name derived from compojure route information:
 If you have a lot of routes or find this to be tedious, it might be worth it creating a custom routes macro that does this automatically. This is not included here because integration with compojure and other routing
 libraries is out of this project's scope.
 
+#### Reitit
+
+If you use [reitit.ring/ring-router](https://github.com/metosin/reitit/blob/master/doc/ring/ring.md#reititringring-router) configured with `:inject-match? true` (default),
+`apm-ring/wrap-apm-transaction` will use the injected `:reitit.core/match :template` value as the _path_ part in transaction name.
+
+For example, given a `reitit.ring/router` route `["/v1/foo/{id}"]`, a GET request to the URI `/v1/foo/124` would yield a transaction named `GET /v1/foo/{id}`.
+
 ## Development
 
 ### Running tests

--- a/src/clojure_elastic_apm/ring.clj
+++ b/src/clojure_elastic_apm/ring.clj
@@ -20,8 +20,11 @@
           (clojure.string/join "/" matches)
           matched?)))))
 
-(defn request->tx-name [{:keys [request-method uri]}]
-  (str (.toUpperCase (name request-method)) " " uri))
+(defn request->tx-name [{:keys [request-method uri] :as request}]
+  (let [path (or
+               (-> request :reitit.core/match :template)
+               uri)]
+    (str (.toUpperCase (name request-method)) " " path)))
 
 (defn wrap-apm-transaction
   ([handler]

--- a/src/clojure_elastic_apm/ring.clj
+++ b/src/clojure_elastic_apm/ring.clj
@@ -20,10 +20,13 @@
           (clojure.string/join "/" matches)
           matched?)))))
 
+(defn request->tx-name [{:keys [request-method uri]}]
+  (str (.toUpperCase (name request-method)) " " uri))
+
 (defn wrap-apm-transaction
   ([handler]
-   (fn [{:keys [request-method uri headers] :as request}]
-     (let [tx-name (str (.toUpperCase (name request-method)) " " uri)
+   (fn [{:keys [headers] :as request}]
+     (let [tx-name (request->tx-name request)
            traceparent (get-in headers ["traceparent"])]
        (with-apm-transaction [tx {:name tx-name :type type-request :traceparent traceparent}]
          (let [{:keys [status] :as response} (handler (assoc request :clojure-elastic-apm/transaction tx))]


### PR DESCRIPTION
This change adds rudimentary support for route match metadata provided by [reitit.ring/router](https://github.com/metosin/reitit/blob/master/doc/ring/ring.md#reititringring-router).

For example, given a `reitit.ring/router` route `["/v1/foo/{id}"]`, a GET request to the URI `/v1/foo/124` would yield a transaction named `GET /v1/foo/{id}` instead of the current `GET /v1/foo/124`.

Understanding
> integration with compojure and other routing libraries is out of this project's scope

I expect this proposal to trigger a discussion about willingness (or lack thereof) to expand the scope.

In my view, Reitit appears to be the _current thing_ in this area.