### PR TITLE
Fix transaction handling in async middleware

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure-elastic-apm "0.9.0"
+(defproject clojure-elastic-apm "0.10.0"
   :description "Clojure wrapper for Elastic APM Java Agent"
   :url "https://github.com/Yleisradio/clojure-elastic-apm"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
`with-apm-transaction` makrolla transaktio suljetaan mahdollisesti ennen kuin asynkroninen handler kutsuu respond-funktiota. Korjataan niin, että transaktio suljetaan vasta respond- ja raise-funktioissa.