### PR TITLE
Fix setting span type (& performance improvements)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The options hash for `with-apm-span` accepts the following options:
 * `:name` - `String` - the span name
 * `:parent` - `Span` - the parent span, the new span will be created as child of this span (defaults to current active span or transaction)
 * `:activate?` - `Boolean` - whether to make the span active in the context of the executing thread (defaults to true). When activated, calling `apm/current-apm-span` returns this span.
+* `:type` - `String` - the span type
 * `:labels` - `{String any}` - map or sequence of label names and values to add to the transaction
 * `:tags` - `{String String}` - ~~map or sequence of label names and values to add to the transaction~~ Deprecated as of 0.5.0
 

--- a/src/clojure_elastic_apm/core.clj
+++ b/src/clojure_elastic_apm/core.clj
@@ -76,11 +76,14 @@
   ([{parent :parent
      span-name :name
      labels :labels
-     tags :tags}]
+     tags :tags
+     span-type :type}]
    (let [parent-span (or parent (current-apm-span))
          child-span (.startSpan ^Span parent-span)]
      (when span-name
        (set-name child-span span-name))
+     (when (string? span-type)
+       (.setType child-span span-type))
      (doseq [[k v] labels]
        (set-label child-span k v))
      (doseq [[k v] tags]

--- a/src/clojure_elastic_apm/core.clj
+++ b/src/clojure_elastic_apm/core.clj
@@ -14,8 +14,8 @@
 
 (defn set-label [^Span span-or-tx k v]
   (cond
-    (instance? Number v) (.setLabel span-or-tx (name k) ^Number v)
-    (instance? Boolean v) (.setLabel span-or-tx (name k) ^boolean v)
+    (number? v) (.setLabel span-or-tx (name k) ^Number v)
+    (boolean? v) (.setLabel span-or-tx (name k) ^boolean v)
     :else (.setLabel span-or-tx (name k) (str v))))
 
 (defn set-name [^Span span-or-tx name]

--- a/src/clojure_elastic_apm/core.clj
+++ b/src/clojure_elastic_apm/core.clj
@@ -40,7 +40,7 @@
 (defn set-outcome-unknown [^Span span-or-tx]
   (set-outcome span-or-tx outcome-unknown))
 
-(defn ^HeaderExtractor trace-extractor [traceparent]
+(defn trace-extractor ^HeaderExtractor [traceparent]
   (reify HeaderExtractor
     (getFirstHeader [_ _] traceparent)))
 

--- a/src/clojure_elastic_apm/ring.clj
+++ b/src/clojure_elastic_apm/ring.clj
@@ -1,13 +1,14 @@
 (ns clojure-elastic-apm.ring
   (:require
+   [clojure.string :as string]
    [clojure-elastic-apm.core :as apm :refer [type-request with-apm-transaction]])
   (:import [co.elastic.apm.api Transaction]))
 
 (set! *warn-on-reflection* true)
 
 (defn match-uri [pattern uri]
-  (let [pattern-segs (clojure.string/split pattern #"/")
-        uri-segs (clojure.string/split uri #"/")
+  (let [pattern-segs (string/split pattern #"/")
+        uri-segs (string/split uri #"/")
         matcher (fn [p u]
                   (cond
                     (= p "*") u
@@ -20,7 +21,7 @@
       (let [matches (map matcher pattern-segs uri-segs)
             matched? (reduce #(and %1 %2) matches)]
         (if matched?
-          (clojure.string/join "/" matches)
+          (string/join "/" matches)
           matched?)))))
 
 (defn match-patterns [patterns uri]

--- a/src/clojure_elastic_apm/ring.clj
+++ b/src/clojure_elastic_apm/ring.clj
@@ -39,7 +39,7 @@
    (fn
      ([{:keys [request-method uri headers] :as request}]
       (let [matched (match-patterns patterns uri)
-            tx-name (str (.toUpperCase (name request-method)) " " matched)
+            tx-name (str (string/upper-case (name request-method)) " " matched)
             traceparent (get-in headers ["traceparent"])]
         (if matched
           (with-apm-transaction [^Transaction tx {:name tx-name :type type-request :traceparent traceparent}]
@@ -50,7 +50,7 @@
           (handler request))))
      ([{:keys [request-method uri headers] :as request} respond raise]
       (let [matched (match-patterns patterns uri)
-            tx-name (str (.toUpperCase (name request-method)) " " matched)
+            tx-name (str (string/upper-case (name request-method)) " " matched)
             traceparent (get-in headers ["traceparent"])]
         (if matched
           (let [tx (apm/start-transaction {:name tx-name :type type-request :traceparent traceparent})

--- a/src/clojure_elastic_apm/ring.clj
+++ b/src/clojure_elastic_apm/ring.clj
@@ -1,6 +1,9 @@
 (ns clojure-elastic-apm.ring
   (:require
-   [clojure-elastic-apm.core :as apm :refer [type-request with-apm-transaction]]))
+   [clojure-elastic-apm.core :as apm :refer [type-request with-apm-transaction]])
+  (:import [co.elastic.apm.api Transaction]))
+
+(set! *warn-on-reflection* true)
 
 (defn match-uri [pattern uri]
   (let [pattern-segs (clojure.string/split pattern #"/")
@@ -38,7 +41,7 @@
             tx-name (str (.toUpperCase (name request-method)) " " matched)
             traceparent (get-in headers ["traceparent"])]
         (if matched
-          (with-apm-transaction [tx {:name tx-name :type type-request :traceparent traceparent}]
+          (with-apm-transaction [^Transaction tx {:name tx-name :type type-request :traceparent traceparent}]
             (let [{:keys [status] :as response} (handler (assoc request :clojure-elastic-apm/transaction tx))]
               (when status
                 (.setResult tx (str "HTTP " status)))

--- a/src/clojure_elastic_apm/ring.clj
+++ b/src/clojure_elastic_apm/ring.clj
@@ -40,7 +40,7 @@
      ([{:keys [request-method uri headers] :as request}]
       (let [matched (match-patterns patterns uri)
             tx-name (str (string/upper-case (name request-method)) " " matched)
-            traceparent (get-in headers ["traceparent"])]
+            traceparent (get headers "traceparent")]
         (if matched
           (with-apm-transaction [^Transaction tx {:name tx-name :type type-request :traceparent traceparent}]
             (let [{:keys [status] :as response} (handler (assoc request :clojure-elastic-apm/transaction tx))]
@@ -51,7 +51,7 @@
      ([{:keys [request-method uri headers] :as request} respond raise]
       (let [matched (match-patterns patterns uri)
             tx-name (str (string/upper-case (name request-method)) " " matched)
-            traceparent (get-in headers ["traceparent"])]
+            traceparent (get headers "traceparent")]
         (if matched
           (let [tx (apm/start-transaction {:name tx-name :type type-request :traceparent traceparent})
                 req (assoc request :clojure-elastic-apm/transaction tx)]

--- a/test/clojure_elastic_apm/core_test.clj
+++ b/test/clojure_elastic_apm/core_test.clj
@@ -49,7 +49,7 @@
       (reset! transaction-id (.getId tx))
       (apm/set-name tx "TestWithSpans")
       (is (= (.getId tx) (.getId (apm/current-apm-span))))
-      (apm/with-apm-span [span {:name "TestSpan" :tags {"t1" "1"}}]
+      (apm/with-apm-span [span {:name "TestSpan" :tags {"t1" "1"} :type "type1"}]
         (reset! span-id (.getId span))
         (Thread/sleep 100)
         (apm/set-label span "t1" "1")
@@ -61,6 +61,7 @@
           span-details (es-find-first-document (str "(processor.event:span%20AND%20span.id:" @span-id ")"))]
       (is (= "TestSpan" (get-in span-details [:span :name])))
       (is (= "1" (get-in span-details [:labels :t1])))
+      (is (= "type1" (get-in span-details [:span :type])))
       (is (= @transaction-id (get-in span-details [:transaction :id])))
       (is (= 1 (get-in tx-details [:transaction :span_count :started])))
       (is (= "failure" (get-in span-details [:event :outcome]))))))

--- a/test/clojure_elastic_apm/ring_test.clj
+++ b/test/clojure_elastic_apm/ring_test.clj
@@ -6,22 +6,22 @@
 
 (deftest match-uri-test
   (testing "* matches and returns value"
-    (= (apm-ring/match-uri "/*/*" "/v1/foo") "/v1/foo")
-    (= (apm-ring/match-uri "/*/*/*" "/v1/foo/bar") "/v1/foo/bar"))
+    (is (= (apm-ring/match-uri "/*/*" "/v1/foo") "/v1/foo"))
+    (is (= (apm-ring/match-uri "/*/*/*" "/v1/foo/bar") "/v1/foo/bar")))
   (testing "_ matches but ignores value"
-    (= (apm-ring/match-uri "/*/_" "/v1/foo") "/v1/_")
-    (= (apm-ring/match-uri "/_/foo" "/v1/foo") "/_/foo"))
+    (is (= (apm-ring/match-uri "/*/_" "/v1/foo") "/v1/_"))
+    (is (= (apm-ring/match-uri "/_/foo" "/v1/foo") "/_/foo")))
   (testing "exact string matches and returns value"
-    (= (apm-ring/match-uri "/v1/*" "/v1/foo") "/v1/foo")
-    (= (apm-ring/match-uri "/*/foo" "/v2/foo") "/v2/foo")
-    (= (apm-ring/match-uri "/v1/*" "/v2/bar") false))
+    (is (= (apm-ring/match-uri "/v1/*" "/v1/foo") "/v1/foo"))
+    (is (= (apm-ring/match-uri "/*/foo" "/v2/foo") "/v2/foo"))
+    (is (= (apm-ring/match-uri "/v1/*" "/v2/bar") false)))
   (testing "matches are eager, and will match a longer URL"
-    (= (apm-ring/match-uri "/*" "/v1/foo/bar") "/v1"))
+    (is (= (apm-ring/match-uri "/*" "/v1/foo/bar") "/v1")))
   (testing "but a shorter URL won't match a longer pattern"
-    (= (apm-ring/match-uri "/*/*/*/*" "/v1/foo") false))
+    (is (= (apm-ring/match-uri "/*/*/*/*" "/v1/foo") false)))
   (testing "trailing slashes don't affect matches"
-    (= (apm-ring/match-uri "/*/*/" "/v1/foo") "/v1/foo")
-    (= (apm-ring/match-uri "/*/*" "/v1/foo/") "/v1/foo")))
+    (is (= (apm-ring/match-uri "/*/*/" "/v1/foo") "/v1/foo"))
+    (is (= (apm-ring/match-uri "/*/*" "/v1/foo/") "/v1/foo"))))
 
 (deftest wrap-apm-transaction-test
   (let [transaction-id (atom nil)


### PR DESCRIPTION
Lisätään tuki `with-apm-span`:in `:type`-optionille.

Samaan syssyyn pieniä tyylikorjauksia sekä suorituskykyparannuksia:

```clojure
;; Before
(quick-bench (with-apm-transaction [_ {}] (with-apm-span [_ {}] (inc 1))))
Evaluation count : 179778 in 6 samples of 29963 calls.
             Execution time mean : 3,450939 µs
    Execution time std-deviation : 335,238985 ns
   Execution time lower quantile : 3,193403 µs ( 2,5%)
   Execution time upper quantile : 3,921804 µs (97,5%)
                   Overhead used : 1,765000 ns

;; After
(quick-bench (with-apm-transaction [_ {}] (with-apm-span [_ {}] (inc 1))))
Evaluation count : 549588 in 6 samples of 91598 calls.
             Execution time mean : 1,157719 µs
    Execution time std-deviation : 72,250262 ns
   Execution time lower quantile : 1,041892 µs ( 2,5%)
   Execution time upper quantile : 1,231646 µs (97,5%)
                   Overhead used : 1,816042 ns

;; Before
(quick-bench
  (app {:request-method :get
        :uri "/"
        :headers {"Accept" "text/plain"
                  "traceparent" "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"}}))
Evaluation count : 82290 in 6 samples of 13715 calls.
             Execution time mean : 8,314673 µs
    Execution time std-deviation : 825,828589 ns
   Execution time lower quantile : 7,539340 µs ( 2,5%)
   Execution time upper quantile : 9,564021 µs (97,5%)
                   Overhead used : 1,765000 ns

;; After
(quick-bench
  (app {:request-method :get
        :uri "/"
        :headers {"Accept" "text/plain"
                  "traceparent" "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"}}))
Evaluation count : 731310 in 6 samples of 121885 calls.
             Execution time mean : 979,053432 ns
    Execution time std-deviation : 76,448450 ns
   Execution time lower quantile : 882,780252 ns ( 2,5%)
   Execution time upper quantile : 1,077063 µs (97,5%)
                   Overhead used : 1,761198 ns
```

Erot varmasti aika merkityksettömiä käytännössä, mutta koska nämä muutokset eivät tee koodista mitenkään erikoista tai epäidiomaattista, niin matalalla roikkuvat hedelmät voi mielestäni hyvin poimia. Näitä funktioita kuitenkin kutsutaan aika paljon.