### PR TITLE
Implement defnspan

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure-elastic-apm "0.11.0"
+(defproject clojure-elastic-apm "0.12.0"
   :description "Clojure wrapper for Elastic APM Java Agent"
   :url "https://github.com/Yleisradio/clojure-elastic-apm"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
defnspan is like defn, but it executes its body within an APM span (via with-apm-span). Additionally, it passes any function metadata in the "apm" namespace (e.g. {:apm/type "db"}) as with-apm-span options.

I've tested defnspan with AOT-compilation and direct linking enabled.