### PR TITLE
Fix numeric labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ So, add these to your project.clj dependencies:
 
 ```clojure
 [co.elastic.apm/apm-agent-api "AGENT_VERSION"]
-[clojure-elastic-apm "0.13.0"]
+[clojure-elastic-apm "0.13.1"]
 ```
 
 Note, in the agent configuration, the `elastic.apm.application_packages` option should be the top level namespace in your

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure-elastic-apm "0.13.0"
+(defproject clojure-elastic-apm "0.13.1"
   :description "Clojure wrapper for Elastic APM Java Agent"
   :url "https://github.com/Yleisradio/clojure-elastic-apm"
   :license {:name "Eclipse Public License"

--- a/src/clojure_elastic_apm/core.clj
+++ b/src/clojure_elastic_apm/core.clj
@@ -14,7 +14,10 @@
   (.setLabel span-or-tx (name k) (str v)))
 
 (defn set-label [^Span span-or-tx k v]
-  (.setLabel span-or-tx (name k) (str v)))
+  (cond
+    (number? v) (.setLabel span-or-tx (name k) ^Number v)
+    (boolean? v) (.setLabel span-or-tx (name k) ^boolean v)
+    :else (.setLabel span-or-tx (name k) (str v))))
 
 (defn set-name [^Span span-or-tx name]
   (.setName span-or-tx name))

--- a/test/clojure_elastic_apm/core_test.clj
+++ b/test/clojure_elastic_apm/core_test.clj
@@ -31,7 +31,7 @@
     (let [tx-details (es-find-first-document (str "(processor.event:transaction%20AND%20transaction.id:" @transaction-id ")"))]
       (is (= "TestTransaction" (get-in tx-details [:transaction :name])))
       (is (= "1" (get-in tx-details [:labels :t1])))
-      (is (= "2" (get-in tx-details [:labels :t2])))
+      (is (= 2 (get-in tx-details [:numeric_labels :t2])))
       (is (= "true" (get-in tx-details [:labels :t3])))
       (is (= "Label 4" (get-in tx-details [:labels :t4])))
       (is (= "test-result" (get-in tx-details [:transaction :result])))


### PR DESCRIPTION
Elastic APM 8.x varastoikin labelit, joilla on numeerinen arvo `numeric_labels`-kentän alle.